### PR TITLE
Fix empty scenario bug

### DIFF
--- a/simglucose/simulation/scenario.py
+++ b/simglucose/simulation/scenario.py
@@ -31,12 +31,14 @@ class CustomScenario(Scenario):
         self.scenario = scenario
 
     def get_action(self, t):
-        times, actions = tuple(zip(*self.scenario))
-        times2compare = [parseTime(time, self.start_time) for time in times]
-        if t in times2compare:
-            idx = times2compare.index(t)
-            return Action(meal=actions[idx])
+        if not self.scenario:
+            return Action(meal=0)
         else:
+            times, actions = tuple(zip(*self.scenario))
+            times2compare = [parseTime(time, self.start_time) for time in times]
+            if t in times2compare:
+                idx = times2compare.index(t)
+                return Action(meal=actions[idx])
             return Action(meal=0)
 
     def reset(self):


### PR DESCRIPTION
The commit fixes an error that occurs when setting an empty list as a scenario parameter when creating a `CustomScenario`. At the moment you can either pass no list (input route) or a list with meals. But if you don't want to simulate meals you currently have to set `CustomScenario(start_time=t, scenario=[[0,0]])` which doesn't seem very intuitive. This commit allows the use of `CustomScenario(start_time=t, scenario=[])`.