### PR TITLE
bug fix of custom-scenario-functionality in gym

### DIFF
--- a/simglucose/envs/simglucose_gym_env.py
+++ b/simglucose/envs/simglucose_gym_env.py
@@ -34,6 +34,7 @@ class T1DSimEnv(gym.Env):
         if patient_name is None:
             patient_name = 'adolescent#001'
         self.patient_name = patient_name
+        self.custom_scenario = custom_scenario
         self.reward_fun = reward_fun
         self.np_random, _ = seeding.np_random(seed=seed)
         self.env, _, _, _ = self._create_env_from_random_state(custom_scenario)
@@ -46,7 +47,7 @@ class T1DSimEnv(gym.Env):
         return self.env.step(act, reward_fun=self.reward_fun)
 
     def _reset(self):
-        self.env, _, _, _ = self._create_env_from_random_state()
+        self.env, _, _, _ = self._create_env_from_random_state(self.custom_scenario)
         obs, _, _, _ = self.env.reset()
         return obs
 


### PR DESCRIPTION
Hi,

I happened to find that custom scenarios were not correctly applied during experimentation with simglucose in OpenAI Gym. This was caused by the missing of custom_scenario param in _reset function. 

I fixed this already.

Have a great day,
Jingyi