### PR TITLE
Init gym env with list of patients/meals

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,28 @@ simulate(sim_time=my_sim_time,
 import gym
 
 # Register gym environment. By specifying kwargs,
-# you are able to choose which patient to simulate.
+# you are able to choose which patient or patients to simulate.
 # patient_name must be 'adolescent#001' to 'adolescent#010',
 # or 'adult#001' to 'adult#010', or 'child#001' to 'child#010'
+# It can also be a list of patient names
+# You can also specify a custom scenario or a list of custom scenarios
+# If you chose a list of patient names or a list of custom scenarios,
+# every time the environment is reset, a random patient and scenario will be
+# chosen from the list
+
 from gym.envs.registration import register
+from simglucose.simulation.scenario import CustomScenario
+from datetime import datetime
+
+start_time = datetime(2018, 1, 1, 0, 0, 0)
+meal_scenario = CustomScenario(start_time=start_time, scenario=[(1,20)])
+
+
 register(
     id='simglucose-adolescent2-v0',
     entry_point='simglucose.envs:T1DSimEnv',
-    kwargs={'patient_name': 'adolescent#002'}
+    kwargs={'patient_name': 'adolescent#002',
+            'custom_scenario': meal_scenario}
 )
 
 env = gym.make('simglucose-adolescent2-v0')

--- a/simglucose/envs/simglucose_gym_env.py
+++ b/simglucose/envs/simglucose_gym_env.py
@@ -32,12 +32,13 @@ class T1DSimEnv(gym.Env):
         # have to hard code the patient_name, gym has some interesting
         # error when choosing the patient
         if patient_name is None:
-            patient_name = 'adolescent#001'
+            patient_name = ['adolescent#001']
+
         self.patient_name = patient_name
         self.reward_fun = reward_fun
         self.np_random, _ = seeding.np_random(seed=seed)
         self.custom_scenario = custom_scenario
-        self.env, _, _, _ = self._create_env_from_random_state(custom_scenario)
+        self.env, _, _, _ = self._create_env()
 
     def _step(self, action):
         # This gym only controls basal insulin
@@ -47,7 +48,7 @@ class T1DSimEnv(gym.Env):
         return self.env.step(act, reward_fun=self.reward_fun)
 
     def _reset(self):
-        self.env, _, _, _ = self._create_env_from_random_state(self.custom_scenario)
+        self.env, _, _, _ = self._create_env()
         obs, _, _, _ = self.env.reset()
         return obs
 
@@ -56,7 +57,7 @@ class T1DSimEnv(gym.Env):
         self.env, seed2, seed3, seed4 = self._create_env_from_random_state()
         return [seed1, seed2, seed3, seed4]
 
-    def _create_env_from_random_state(self, custom_scenario=None):
+    def _create_env(self):
         # Derive a random seed. This gets passed as a uint, but gets
         # checked as an int elsewhere, so we need to keep it below
         # 2**31.
@@ -66,9 +67,20 @@ class T1DSimEnv(gym.Env):
 
         hour = self.np_random.randint(low=0.0, high=24.0)
         start_time = datetime(2018, 1, 1, hour, 0, 0)
-        patient = T1DPatient.withName(self.patient_name, random_init_bg=True, seed=seed4)
+        
+
+        if isinstance(self.patient_name, list):
+            patient_name = self.np_random.choice(self.patient_name)
+            patient = T1DPatient.withName(patient_name, random_init_bg=True, seed=seed4)
+        else:
+            patient = T1DPatient.withName(self.patient_name, random_init_bg=True, seed=seed4)
+
+        if isinstance(self.custom_scenario, list):
+           scenario = self.np_random.choice(self.custom_scenario)
+        else:
+            scenario = RandomScenario(start_time=start_time, seed=seed3) if self.custom_scenario is None else self.custom_scenario
+        
         sensor = CGMSensor.withName(self.SENSOR_HARDWARE, seed=seed2)
-        scenario = RandomScenario(start_time=start_time, seed=seed3) if custom_scenario is None else custom_scenario
         pump = InsulinPump.withName(self.INSULIN_PUMP_HARDWARE)
         env = _T1DSimEnv(patient, sensor, pump, scenario)
         return env, seed2, seed3, seed4

--- a/simglucose/envs/simglucose_gym_env.py
+++ b/simglucose/envs/simglucose_gym_env.py
@@ -54,7 +54,7 @@ class T1DSimEnv(gym.Env):
 
     def _seed(self, seed=None):
         self.np_random, seed1 = seeding.np_random(seed=seed)
-        self.env, seed2, seed3, seed4 = self._create_env_from_random_state()
+        self.env, seed2, seed3, seed4 = self._create_env()
         return [seed1, seed2, seed3, seed4]
 
     def _create_env(self):
@@ -66,8 +66,7 @@ class T1DSimEnv(gym.Env):
         seed4 = seeding.hash_seed(seed3 + 1) % 2**31
 
         hour = self.np_random.randint(low=0.0, high=24.0)
-        start_time = datetime(2018, 1, 1, hour, 0, 0)
-        
+        start_time = datetime(2018, 1, 1, hour, 0, 0)    
 
         if isinstance(self.patient_name, list):
             patient_name = self.np_random.choice(self.patient_name)

--- a/tests/test_gym_custom_scenario.py
+++ b/tests/test_gym_custom_scenario.py
@@ -30,7 +30,7 @@ class TestCustomScenario(unittest.TestCase):
         reward = 0
         done = False
 
-        sample_step = 3
+        sample_step = env.env.sensor.sample_time
 
         info = {'sample_time': sample_step,
                 'patient_name': 'adolescent#002',

--- a/tests/test_gym_custom_scenario.py
+++ b/tests/test_gym_custom_scenario.py
@@ -1,0 +1,61 @@
+import gym
+import unittest
+from simglucose.simulation.scenario import CustomScenario
+from simglucose.controller.basal_bolus_ctrller import BBController
+import datetime as dt
+
+
+class TestCustomScenario(unittest.TestCase):
+    def test_custom_scenario(self):
+        start_time = dt.datetime(2018, 1, 1, 0, 0, 0)
+
+        meals = [(1,50),(2,10),(3,20)]
+        meals_checked = [False for _ in range(len(meals))]
+
+        current_pos = 0
+
+        custom_meal_scenario = CustomScenario(start_time=start_time, scenario=meals)
+
+
+        gym.envs.register(
+            id='env-v0',
+            entry_point='simglucose.envs:T1DSimEnv',
+            kwargs={'patient_name': 'adult#001',
+                'custom_scenario': custom_meal_scenario}
+        )
+
+        env = gym.make('env-v0')
+        ctrller = BBController()
+
+        reward = 0
+        done = False
+
+        sample_step = 3
+
+        info = {'sample_time': sample_step,
+                'patient_name': 'adolescent#002',
+                'meal': 0}
+
+        observation = env.reset()
+        for t in range(61):
+            env.render(mode='human')
+
+            ctrl_action = ctrller.policy(observation, reward, done, **info)
+            action = ctrl_action.basal + ctrl_action.bolus
+            observation, reward, done, info = env.step(action)
+
+
+            if info["meal"] > 0 and t*sample_step == (meals[current_pos][0]*60):
+                meals_checked[current_pos] = True
+                current_pos += 1
+
+
+            if done:
+                print("Episode finished after {} timesteps".format(t + 1))
+                break
+
+        assert(all(meals_checked))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I added the possibility to create a gym env with multiple patients and meals.
Every time the env is reseted, a new patient/meal is randomly sampled.
I also changed the `_create_env_from_random_state(custom_scenario)` name and parameter to
`_create_env()` because the custom_scenario is an instance variable.
```
from datetime import datetime
import gym
import simglucose
from simglucose.simulation.scenario import CustomScenario
import numpy as np



start_time = datetime(2018, 1, 1, 0, 0, 0)
meal_scenario_1 = CustomScenario(start_time=start_time, scenario=[(1,20)])
meal_scenario_2 = CustomScenario(start_time=start_time,scenario=[(3,15)])


patient_name = ['adult#001','adult#002','adult#003','adult#004','adult#005','adult#006','adult#007','adult#008','adult#009','adult#010']

gym.envs.register(
    id='env-v0',
    entry_point="simglucose.envs:T1DSimEnv",
    kwargs={'patient_name': patient_name,
           'custom_scenario': [meal_scenario_1, meal_scenario_2]}
)

env = gym.make('env-v0')

env.reset()

min_insulin = env.action_space.low
max_insulin = env.action_space.high

observation = env.reset()
for t in range(100):
    env.render(mode='human')
    #action = np.random.uniform(min_insulin, max_insulin)
    
    action = observation.CGM * 0.0005
    if observation.CGM < 120:
        action = 0
    
    #print(action)
    observation, reward, done, info = env.step(action)
    if done:
        print("Episode finished after {} timesteps".format(t + 1))
        break

```