### PR TITLE
Refactored kgut parameters alpha and beta

### DIFF
--- a/simglucose/patient/t1dpatient.py
+++ b/simglucose/patient/t1dpatient.py
@@ -133,8 +133,8 @@ class T1DPatient(Patient):
         dxdt[0] = -params.kmax * x[0] + d
 
         if Dbar > 0:
-            aa = 5 / 2 / (1 - params.b) / Dbar
-            cc = 5 / 2 / params.d / Dbar
+            aa = 5 / (2 * Dbar * (1 - params.b))
+            cc = 5 / (2 * Dbar * params.d)
             kgut = params.kmin + (params.kmax - params.kmin) / 2 * (
                 np.tanh(aa * (qsto - params.b * Dbar)) -
                 np.tanh(cc * (qsto - params.d * Dbar)) + 2)


### PR DESCRIPTION
Fixing #75 

I have updated the parameters **alpha (aa)** and **beta (bb)** that are used in calculating the **empting rate, kempt(qsto)** of the liquid compartment of the stomach, referred to as **kgut** in this code to match the paper highlighted in Issue #75 