### PR TITLE
Issue #97 Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/simglucose/actuator/pump.py
+++ b/simglucose/actuator/pump.py
@@ -1,10 +1,9 @@
 import pandas as pd
-import pkg_resources
+from importlib.resources import files
 import logging
 import numpy as np
 
-INSULIN_PUMP_PARA_FILE = pkg_resources.resource_filename(
-    'simglucose', 'params/pump_params.csv')
+INSULIN_PUMP_PARA_FILE = str(files('simglucose') / 'params' / 'pump_params.csv')
 logger = logging.getLogger(__name__)
 
 

--- a/simglucose/controller/basal_bolus_ctrller.py
+++ b/simglucose/controller/basal_bolus_ctrller.py
@@ -2,14 +2,12 @@ from .base import Controller
 from .base import Action
 import numpy as np
 import pandas as pd
-import pkg_resources
+from importlib.resources import files
 import logging
 
 logger = logging.getLogger(__name__)
-CONTROL_QUEST = pkg_resources.resource_filename('simglucose',
-                                                'params/Quest.csv')
-PATIENT_PARA_FILE = pkg_resources.resource_filename(
-    'simglucose', 'params/vpatient_params.csv')
+CONTROL_QUEST = str(files('simglucose') / 'params' / 'Quest.csv')
+PATIENT_PARA_FILE = str(files('simglucose') / 'params' / 'vpatient_params.csv')
 
 
 class BBController(Controller):

--- a/simglucose/envs/simglucose_gym_env.py
+++ b/simglucose/envs/simglucose_gym_env.py
@@ -5,7 +5,7 @@ from simglucose.actuator.pump import InsulinPump
 from simglucose.simulation.scenario_gen import RandomScenario
 from simglucose.controller.base import Action
 import numpy as np
-import pkg_resources
+from importlib.resources import files
 import gym
 from gym import spaces
 from gym.utils import seeding
@@ -13,9 +13,7 @@ from datetime import datetime
 import gymnasium
 
 
-PATIENT_PARA_FILE = pkg_resources.resource_filename(
-    "simglucose", "params/vpatient_params.csv"
-)
+PATIENT_PARA_FILE = str(files("simglucose") / "params" / "vpatient_params.csv")
 
 
 class T1DSimEnv(gym.Env):

--- a/simglucose/patient/t1dpatient.py
+++ b/simglucose/patient/t1dpatient.py
@@ -4,16 +4,14 @@ from scipy.integrate import ode
 import pandas as pd
 from collections import namedtuple
 import logging
-import pkg_resources
+from importlib.resources import files
 
 logger = logging.getLogger(__name__)
 
 Action = namedtuple("patient_action", ["CHO", "insulin"])
 Observation = namedtuple("observation", ["Gsub"])
 
-PATIENT_PARA_FILE = pkg_resources.resource_filename(
-    "simglucose", "params/vpatient_params.csv"
-)
+PATIENT_PARA_FILE = str(files("simglucose") / "params" / "vpatient_params.csv")
 
 
 class T1DPatient(Patient):

--- a/simglucose/sensor/cgm.py
+++ b/simglucose/sensor/cgm.py
@@ -2,11 +2,10 @@
 from .noise_gen import CGMNoise
 import pandas as pd
 import logging
-import pkg_resources
+from importlib.resources import files
 
 logger = logging.getLogger(__name__)
-SENSOR_PARA_FILE = pkg_resources.resource_filename(
-    'simglucose', 'params/sensor_params.csv')
+SENSOR_PARA_FILE = str(files('simglucose') / 'params' / 'sensor_params.csv')
 
 
 class CGMSensor(object):

--- a/simglucose/simulation/user_interface.py
+++ b/simglucose/simulation/user_interface.py
@@ -9,7 +9,7 @@ from simglucose.simulation.scenario import CustomScenario
 from simglucose.analysis.report import report
 import pandas as pd
 import copy
-import pkg_resources
+from importlib.resources import files
 import logging
 import os
 from datetime import datetime
@@ -18,15 +18,9 @@ import platform
 
 logger = logging.getLogger(__name__)
 
-PATIENT_PARA_FILE = pkg_resources.resource_filename(
-    "simglucose", "params/vpatient_params.csv"
-)
-SENSOR_PARA_FILE = pkg_resources.resource_filename(
-    "simglucose", "params/sensor_params.csv"
-)
-INSULIN_PUMP_PARA_FILE = pkg_resources.resource_filename(
-    "simglucose", "params/pump_params.csv"
-)
+PATIENT_PARA_FILE = str(files("simglucose") / "params" / "vpatient_params.csv")
+SENSOR_PARA_FILE = str(files("simglucose") / "params" / "sensor_params.csv")
+INSULIN_PUMP_PARA_FILE = str(files("simglucose") / "params" / "pump_params.csv")
 
 
 def pick_patients():

--- a/simglucose/utils.py
+++ b/simglucose/utils.py
@@ -1,10 +1,8 @@
-import pkg_resources
+from importlib.resources import files
 import pandas as pd
 
-CONTROL_QUEST = pkg_resources.resource_filename('simglucose',
-                                                'params/Quest.csv')
-PATIENT_PARA_FILE = pkg_resources.resource_filename(
-    'simglucose', 'params/vpatient_params.csv')
+CONTROL_QUEST = str(files('simglucose') / 'params' / 'Quest.csv')
+PATIENT_PARA_FILE = str(files('simglucose') / 'params' / 'vpatient_params.csv')
 
 
 def fetch_patient_params(patient_name: str):


### PR DESCRIPTION

## Summary
Replaces the deprecated `pkg_resources` API with the standard-library
`importlib.resources` for locating bundled CSV parameter files.

- `import pkg_resources` → `from importlib.resources import files`
- `pkg_resources.resource_filename("simglucose", "params/x.csv")`
  → `str(files("simglucose") / "params" / "x.csv")`

`importlib.resources.files()` is available since Python 3.9 (the
project's minimum supported version), so this adds no new dependency and
removes reliance on a deprecated API.

Closes issue #97

## Files changed
- simglucose/sensor/cgm.py
- simglucose/actuator/pump.py
- simglucose/utils.py
- simglucose/controller/basal_bolus_ctrller.py
- simglucose/patient/t1dpatient.py
- simglucose/envs/simglucose_gym_env.py
- simglucose/simulation/user_interface.py

## Testing
- Verified all four resolved paths point to the existing CSV files and a
  patient loads correctly.
- Full test suite passes: `15 passed` (same as before the change).